### PR TITLE
Add ability for logged-in users to overwrite unverified raffles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Added
 - Added a confirmation popup for raffle parameters on form submit.
 - Added a "show more" button on user profile pages to prevent showing too many raffles at once.
+- Existing unverified raffles can now be overwritten by verified raffles. Logged-in users should be able to select their submission when creating a new raffle and unverified raffles will be removed automatically upon successful creation of the verified one.
 
 ### Changed
 - Use simpler versioning scheme (increment with each release) instead of SemVer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Added
 - Added a confirmation popup for raffle parameters on form submit.
 - Added a "show more" button on user profile pages to prevent showing too many raffles at once.
-- Existing unverified raffles can now be overwritten by verified raffles. Logged-in users should be able to select their submission when creating a new raffle and unverified raffles will be removed automatically upon successful creation of the verified one.
+- Existing unverified raffles can now be overwritten by verified raffles. Logged-in users should be able to select their submission when creating a new raffle; unverified raffles will be removed automatically upon successful creation of the verified one.
 
 ### Changed
 - Use simpler versioning scheme (increment with each release) instead of SemVer.

--- a/app/util/raffle_form_validator.py
+++ b/app/util/raffle_form_validator.py
@@ -62,10 +62,14 @@ class RaffleFormValidator():
 
     def _validate_raffle_not_exists(self):
         """ Checks that the submission URL given has not already been made
-        into a raffle. """
+        into a verified raffle. """
         url = self.ensure_protocol(self.form.get('submissionUrl'))
         sub_id = reddit.submission_id_from_url(url)
-        if Raffle.query.filter_by(submission_id=sub_id).scalar():
+        has_existing_raffle = Raffle.query \
+                                    .filter(Raffle.submission_id == sub_id) \
+                                    .filter(Raffle.user_id != None) \
+                                    .scalar()
+        if has_existing_raffle:
             raise ValueError("Raffle already exists for {}".format(sub_id))
 
     def _validate_ignored_users_list(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 from app.config import TestConfig
 from app.factory import create_app
 from app.extensions import db as _db
-from app.db.models import Raffle
+from app.db.models import Raffle, User
 import pytest
 
 
@@ -36,7 +36,15 @@ def db_session(db, request):
 
 
 @pytest.fixture
-def raffle(db_session):
+def user(db_session):
+    user = User(username='test_user')
+    db_session.add(user)
+    db_session.commit()
+    return user
+
+
+@pytest.fixture
+def raffle(db_session, user):
     raffle = Raffle(submission_id='test_id',
                     submission_title='test_title',
                     submission_author='test_author',
@@ -44,7 +52,8 @@ def raffle(db_session):
                     winner_count=1,
                     min_account_age=0,
                     min_comment_karma=0,
-                    min_link_karma=0)
+                    min_link_karma=0,
+                    user_id=user.id)
     db_session.add(raffle)
     db_session.commit()
     return raffle


### PR DESCRIPTION
Resolves #53 

* Filter only verified raffles when returning a user's reddit submissions
* Update raffle fixture in tests to be verified instead of unverified
* Changed form validator to 
* Delete unverified raffles before saving new verified raffle